### PR TITLE
feat: Add HEALTH_RETRIES & HEALTH_RETRY_DELAY to stackhawk to retry curl healthchecks

### DIFF
--- a/.github/workflows/stackhawk.yaml
+++ b/.github/workflows/stackhawk.yaml
@@ -28,6 +28,14 @@ on:  # yamllint disable-line rule:truthy
         default: 'actuator/health'
         required: false
         type: string
+      HEALTH_RETRIES:
+        default: 3
+        required: false
+        type: number
+      HEALTH_RETRY_DELAY:
+        default: 10
+        required: false
+        type: number
       STACKHAWK_SETUP_SCRIPT_NAME:
         default: 'setup-stackhawk.sh'
         required: false
@@ -108,9 +116,11 @@ jobs:
           APP_HOST: https://${{ inputs.NAMESPACE }}.${{ inputs.BASE_DOMAIN }}
           API_PATH: ${{ inputs.API_PATH }}
           HEALTH_PATH: ${{ inputs.HEALTH_PATH }}
+          HEALTH_RETRIES: ${{ inputs.HEALTH_RETRIES }}
+          HEALTH_RETRY_DELAY: ${{ inputs.HEALTH_RETRY_DELAY }}
         run: |
           echo "CHECKING: ${APP_HOST}${API_PATH}${HEALTH_PATH}"
-          curl ${APP_HOST}${API_PATH}${HEALTH_PATH}
+          curl --fail --retry ${HEALTH_RETRIES} --retry-delay ${HEALTH_RETRY_DELAY} --retry-all-errors ${APP_HOST}${API_PATH}${HEALTH_PATH}
 
       - name: "🦅 Run Stackhawk (timeout ${{ inputs.JOBS_TIMEOUT }} minutes)"
         env:


### PR DESCRIPTION
Adds default of 3 retries with 10 second delay between each retry to 
hopefully help avoid stackhawk failing while backends are starting up in PRs.

`--fail` is because 404's aren't treated as a transfer failure.