### PR TITLE
feat: increase stackhawk default health retries to 6

### DIFF
--- a/.github/workflows/stackhawk.yaml
+++ b/.github/workflows/stackhawk.yaml
@@ -29,7 +29,7 @@ on:  # yamllint disable-line rule:truthy
         required: false
         type: string
       HEALTH_RETRIES:
-        default: 3
+        default: 6
         required: false
         type: number
       HEALTH_RETRY_DELAY:


### PR DESCRIPTION
3 x 10 second delay doesn't seem to be enough for a lot of backend services.