### PR TITLE
feat: add STACKHAWK_SLEEP_DELAY to give helm install time before initial curl call

### DIFF
--- a/.github/workflows/stackhawk.yaml
+++ b/.github/workflows/stackhawk.yaml
@@ -40,6 +40,10 @@ on:  # yamllint disable-line rule:truthy
         default: ''
         required: false
         type: string
+      STACKHAWK_SLEEP_DELAY:
+        default: 15
+        required: false
+        type: number
       STACKHAWK_SETUP_SCRIPT_NAME:
         default: 'setup-stackhawk.sh'
         required: false
@@ -127,7 +131,9 @@ jobs:
           HEALTH_PATH: ${{ inputs.HEALTH_PATH }}
           HEALTH_RETRIES: ${{ inputs.HEALTH_RETRIES }}
           HEALTH_RETRY_DELAY: ${{ inputs.HEALTH_RETRY_DELAY }}
+          STACKHAWK_SLEEP_DELAY: ${{ inputs.STACKHAWK_SLEEP_DELAY }}
         run: |
+          sleep ${STACKHAWK_SLEEP_DELAY}
           echo "CHECKING: ${APP_HOST}${API_PATH}${HEALTH_PATH}"
           curl --fail --retry ${HEALTH_RETRIES} --retry-delay ${HEALTH_RETRY_DELAY} ${{ inputs.CURL_ARGS }} ${APP_HOST}${API_PATH}${HEALTH_PATH}
 


### PR DESCRIPTION
Thinking that stackhawk may be running curl too quickly after helm install and getting a 404 from istio which fails the step.