### PR TITLE
fix: update maven-docker google-github-actions/auth to v2

### DIFF
--- a/.github/workflows/deploy-jar-registry.yaml
+++ b/.github/workflows/deploy-jar-registry.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: "🔧 Google Auth Token"
         if: ${{ !env.ACT }}
         id: auth-gcp-token
-        uses: 'google-github-actions/auth@v0'
+        uses: 'google-github-actions/auth@v2'
         with:
           token_format: 'access_token'
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: "🔧 Google Auth Token"
         if: ${{ !env.ACT }}
         id: auth-gcp-token
-        uses: 'google-github-actions/auth@v0'
+        uses: 'google-github-actions/auth@v2'
         with:
           token_format: 'access_token'
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'

--- a/.github/workflows/flyway-cloud-run-job.yaml
+++ b/.github/workflows/flyway-cloud-run-job.yaml
@@ -81,7 +81,7 @@ jobs:
 
       - name: "🔧 Google Auth Token"
         id: auth-gcp-token
-        uses: 'google-github-actions/auth@v0'
+        uses: 'google-github-actions/auth@v2'
         with:
           token_format: 'access_token'
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'

--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -242,7 +242,7 @@ jobs:
       - name: "🔧 Google Auth Token"
         if: ${{ !env.ACT }}
         id: auth-gcp-token
-        uses: 'google-github-actions/auth@v0'
+        uses: 'google-github-actions/auth@v2'
         with:
           token_format: 'access_token'
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'

--- a/.github/workflows/maven-docker.yaml
+++ b/.github/workflows/maven-docker.yaml
@@ -122,7 +122,7 @@ jobs:
 
       - name: "🔧 Google Auth Token"
         id: auth-gcp-token
-        uses: 'google-github-actions/auth@v0'
+        uses: 'google-github-actions/auth@v2'
         with:
           token_format: 'access_token'
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'
@@ -133,7 +133,7 @@ jobs:
       - name: "🔧 Google Auth JSON Key"
         id: auth-gcp-key
         if: inputs.RUN_GCP_JSON_KEY
-        uses: 'google-github-actions/auth@v0'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GCP_JSON_KEY }}'
 

--- a/.github/workflows/node-docker.yaml
+++ b/.github/workflows/node-docker.yaml
@@ -124,7 +124,7 @@ jobs:
       - name: "🔧 Google Auth Token"
         if: ${{ !env.ACT }}
         id: auth-gcp-token
-        uses: 'google-github-actions/auth@v0'
+        uses: 'google-github-actions/auth@v2'
         with:
           token_format: 'access_token'
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'

--- a/.github/workflows/preview-env-cleanup.yaml
+++ b/.github/workflows/preview-env-cleanup.yaml
@@ -110,7 +110,7 @@ jobs:
 
       - name: "🔧 Google Auth Token"
         id: auth-gcp-token
-        uses: 'google-github-actions/auth@v0'
+        uses: 'google-github-actions/auth@v2'
         with:
           token_format: 'access_token'
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: "🔧 Google Auth Token"
         if: ${{ !env.ACT }}
         id: auth-gcp-token
-        uses: 'google-github-actions/auth@v0'
+        uses: 'google-github-actions/auth@v2'
         with:
           token_format: 'access_token'
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'


### PR DESCRIPTION
'The v0 series of google-github-actions/auth is no longer maintained. It will not receive updates, improvements, or security patches. Please upgrade to the latest supported versions'